### PR TITLE
Fix bad implementations of readPrec

### DIFF
--- a/src/Data/Maybe/Unpacked/Numeric/Complex/Double.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Complex/Double.hs
@@ -86,7 +86,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Complex/Float.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Complex/Float.hs
@@ -86,7 +86,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Double.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Double.hs
@@ -53,7 +53,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Float.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Float.hs
@@ -53,7 +53,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Int.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Int.hs
@@ -55,7 +55,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Int16.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Int16.hs
@@ -56,7 +56,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Int32.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Int32.hs
@@ -57,7 +57,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Int64.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Int64.hs
@@ -55,7 +55,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Int8.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Int8.hs
@@ -55,7 +55,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Word.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Word.hs
@@ -55,7 +55,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Word16.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Word16.hs
@@ -55,7 +55,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Word32.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Word32.hs
@@ -55,7 +55,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Word64.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Word64.hs
@@ -55,7 +55,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/src/Data/Maybe/Unpacked/Numeric/Word8.hs
+++ b/src/Data/Maybe/Unpacked/Numeric/Word8.hs
@@ -55,7 +55,7 @@ instance Show Maybe where
 instance Read Maybe where
   readPrec = parens $ nothingP +++ justP
     where
-      nothingP = prec 10 $ do
+      nothingP = do
         Ident "nothing" <- lexP
         return nothing
       justP = prec 10 $ do

--- a/test/spec.hs
+++ b/test/spec.hs
@@ -1,0 +1,15 @@
+import Control.Monad (when)
+
+import qualified Data.Maybe.Unpacked.Numeric.Word as Word
+
+main :: IO ()
+main = do
+  putStrLn "A"
+  when (showsPrec 12 Word.nothing "" /= "nothing") $ do
+    fail "Failed test A"
+  putStrLn "B"
+  when (showsPrec 6 Word.nothing "" /= "nothing") $ do
+    fail "Failed test B"
+  putStrLn "C"
+  when (showsPrec 11 Word.nothing "" /= "nothing") $ do
+    fail "Failed test C"

--- a/unpacked-maybe-numeric.cabal
+++ b/unpacked-maybe-numeric.cabal
@@ -51,6 +51,16 @@ library
   ghc-options: -Wall -O2
   default-language: Haskell2010
 
+test-suite spec
+  default-language: Haskell2010
+  ghc-options: -Wall
+  type: exitcode-stdio-1.0
+  main-is: spec.hs
+  hs-source-dirs: test
+  build-depends:
+    , base
+    , unpacked-maybe-numeric
+
 test-suite laws
   default-language: Haskell2010
   ghc-options: -Wall


### PR DESCRIPTION
Newer versions of quickcheck-classes started catching a mistake in the implementation of readPrec. The problem was that parentheses should never be added around pseudo data constructor `nothing`. However, readPrec required them to be there. The fix is simple: remove `prec 10`.